### PR TITLE
select2-bug-fix

### DIFF
--- a/src/resources/components/select2.blade.php
+++ b/src/resources/components/select2.blade.php
@@ -17,6 +17,6 @@
 @section('js')
     @parent
     <script>
-        $(()=>{ $('#{{$id}}').select2({ theme: 'bootstrap4' }); })
+        $(()=>{ $('#{{$id}}').select2({}); })
     </script>
 @endsection


### PR DESCRIPTION
I am using Laravel 8 and bootstrap 4

Before fix
![Screenshot from 2021-02-03 19-35-22](https://user-images.githubusercontent.com/26204153/106751068-1d053300-6657-11eb-872a-aa2e6425a3cd.png)

After
![Screenshot from 2021-02-03 19-35-35](https://user-images.githubusercontent.com/26204153/106751101-28f0f500-6657-11eb-937b-b6d4cc3be80a.png)

As you can see, select2 borders are missing